### PR TITLE
try windows without removing ripgrep

### DIFF
--- a/recipe/builder.py
+++ b/recipe/builder.py
@@ -10,7 +10,6 @@ CI = os.environ.get("CI")
 
 WIN = platform.system() == "Windows"
 INSTALL_SCRIPT = "verapdf-install.bat" if WIN else "verapdf-install"
-RG_PATH = Path(r"C:\Miniforge\Library\bin\rg.exe")
 
 SRC_DIR = Path(os.environ["SRC_DIR"])
 PKG_VERSION = os.environ["PKG_VERSION"]
@@ -109,12 +108,6 @@ def clean():
     for path in [DEST / "Uninstaller"]:
         print("... cleaning", path, flush=True)
         shutil.rmtree(path)
-
-    if CI and WIN and RG_PATH.exists():
-        print(
-            "... removing ripgrep for https://github.com/conda/conda-build/issues/4357"
-        )
-        RG_PATH.unlink()
 
 
 def main() -> int:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     sha256: b8bf0b00fd789ef8d8548d2eeb7e83194db394d9f1be741f2d0ef1d62bff50c6
 
 build:
-  number: 0
+  number: 1
   ignore_run_exports:
     - python
     - python_abi


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

References:
- as noted in https://github.com/conda-forge/ripgrep-feedstock/issues/19
- testing https://github.com/conda-forge/ripgrep-feedstock/pull/21